### PR TITLE
[feat]: Implement Background Click Close Functionality

### DIFF
--- a/frontend/src/components/Room/AddRoomPanel.tsx
+++ b/frontend/src/components/Room/AddRoomPanel.tsx
@@ -29,8 +29,14 @@ function AddRoomPanel({ hideAddRoomPanel }: any) {
   };
 
   return (
-    <div className="flex absolute top-0 left-0 z-20 flex-col justify-center items-center px-6 py-8 mx-auto w-full h-screen backdrop-blur-sm lg:py-0">
-      <div className="relative w-full bg-white rounded-lg shadow-lg md:mt-0 sm:max-w-md xl:p-0">
+    <div
+      className="flex absolute top-0 left-0 z-20 flex-col justify-center items-center px-6 py-8 mx-auto w-full h-screen backdrop-blur-sm lg:py-0"
+      onClick={() => hideAddRoomPanel(true)}
+    >
+      <div
+        className="relative w-full bg-white rounded-lg shadow-lg md:mt-0 sm:max-w-md xl:p-0"
+        onClick={(e) => e.stopPropagation()}
+      >
         <AiFillCloseCircle
           size={30}
           className="absolute -top-2 -right-2 cursor-pointer text-primary"


### PR DESCRIPTION
# PR Title: [feat]: Implement Background Click Close Functionality

## Closes issue #23 

## Changes Made

This PR introduces functionality enabling the closure of the "Create or Join Room" modal by clicking on the background area outside the form's boundary. 

## Highlights

- Added background click functionality for modal closure.
- Improved user interaction by allowing closure outside the form's boundary.
- Tested if clicking inside the boundary closes it.
- Verified responsiveness and consistency across devices.

## Screenshots

https://github.com/diwash007/kurakani/assets/107195487/34457f58-e72f-4ecf-ae64-3a59b45a35c0

![image](https://github.com/diwash007/kurakani/assets/107195487/aedf8f87-259e-4d84-9f48-e61e98820f4b)

## Additional Details

This enhancement offers users an alternative and intuitive method to dismiss the modal, contributing to a more user-friendly interface. Your review and merge are appreciated to incorporate this enhancement for an improved user experience.